### PR TITLE
fix: support custom OpenRouter models and API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ You can configure Tabminal via command-line arguments, environment variables, or
 | `-h`, `--host` | `HOST` | Bind address | `127.0.0.1` |
 | `-a`, `--password` | `TABMINAL_PASSWORD` | Access password | (Randomly Generated) |
 | `-k`, `--openrouter-key` | `TABMINAL_OPENROUTER_KEY` | AI Provider API Key | `null` |
-| `-m`, `--model` | `TABMINAL_MODEL` | AI Model ID | `gemini-2.5-flash-preview-09-2025` |
+| `-m`, `--model` | `TABMINAL_MODEL` | AI Model ID (supports any OpenRouter model) | `gemini-2.5-flash-preview-09-2025` |
+| `-u`, `--api-base-url` | `TABMINAL_API_BASE_URL` | Custom API base URL (for self-hosted/proxy) | `null` |
 | `-g`, `--google-key` | `TABMINAL_GOOGLE_KEY` | Google Search API Key | `null` |
 | `-c`, `--google-cx` | `TABMINAL_GOOGLE_CX` | Google Search Engine ID (CX) | `null` |
 | `-d`, `--debug` | `TABMINAL_DEBUG` | Enable debug logs | `false` |

--- a/config.sample.json
+++ b/config.sample.json
@@ -4,6 +4,7 @@
   "password": "YOUR_SECURE_PASSWORD",
   "openrouter-key": "YOUR_OPENROUTER_API_KEY",
   "model": "gemini-2.5-flash-preview-09-2025",
+  "api-base-url": null,
   "google-key": "YOUR_GOOGLE_SEARCH_API_KEY",
   "google-cx": "YOUR_GOOGLE_SEARCH_ENGINE_ID",
   "accept-terms": true,

--- a/src/config.mjs
+++ b/src/config.mjs
@@ -12,6 +12,7 @@ const DEFAULT_CONFIG = {
     acceptTerms: false,
     password: null,
     model: 'gemini-2.5-flash-preview-09-2025',
+    apiBaseUrl: null, // Custom API base URL (e.g., for self-hosted or proxy)
     debug: false,
     openrouterKey: null,
     googleKey: null,
@@ -80,6 +81,10 @@ function loadConfig() {
                 type: 'string',
                 short: 'm'
             },
+            'api-base-url': {
+                type: 'string',
+                short: 'u'
+            },
             debug: {
                 type: 'boolean',
                 short: 'd'
@@ -116,6 +121,7 @@ Options:
   --password, -a        Set access password
   --openrouter-key, -k  Set OpenRouter API Key
   --model, -m           Set AI Model
+  --api-base-url, -u    Set custom API base URL (for self-hosted or proxy)
   --google-key, -g      Set Google Search API Key
   --google-cx, -c       Set Google Search Engine ID
   --debug, -d           Enable debug mode
@@ -136,6 +142,7 @@ Options:
     if (finalConfig['accept-terms']) finalConfig.acceptTerms = finalConfig['accept-terms'];
     if (finalConfig['openrouter-key']) finalConfig.openrouterKey = finalConfig['openrouter-key'];
     if (finalConfig['ai-key']) finalConfig.openrouterKey = finalConfig['ai-key']; // Backwards compat
+    if (finalConfig['api-base-url']) finalConfig.apiBaseUrl = finalConfig['api-base-url'];
     if (finalConfig['google-key']) finalConfig.googleKey = finalConfig['google-key'];
     if (finalConfig['google-cx']) finalConfig.googleCx = finalConfig['google-cx'];
 
@@ -157,8 +164,11 @@ Options:
     if (args['openrouter-key']) {
         finalConfig.openrouterKey = args['openrouter-key'];
     }
-    if (args.model) {
+    if (args.model && args.model.trim() !== '') {
         finalConfig.model = args.model;
+    }
+    if (args['api-base-url'] && args['api-base-url'].trim() !== '') {
+        finalConfig.apiBaseUrl = args['api-base-url'];
     }
     if (args.debug) {
         finalConfig.debug = true;
@@ -177,10 +187,21 @@ Options:
     if (process.env.TABMINAL_HISTORY) finalConfig.historyLimit = parseInt(process.env.TABMINAL_HISTORY, 10);
     if (process.env.TABMINAL_PASSWORD) finalConfig.password = process.env.TABMINAL_PASSWORD;
     if (process.env.TABMINAL_OPENROUTER_KEY) finalConfig.openrouterKey = process.env.TABMINAL_OPENROUTER_KEY;
-    if (process.env.TABMINAL_MODEL) finalConfig.model = process.env.TABMINAL_MODEL;
+    if (process.env.TABMINAL_MODEL && process.env.TABMINAL_MODEL.trim() !== '') {
+        finalConfig.model = process.env.TABMINAL_MODEL;
+    }
+    if (process.env.TABMINAL_API_BASE_URL && process.env.TABMINAL_API_BASE_URL.trim() !== '') {
+        finalConfig.apiBaseUrl = process.env.TABMINAL_API_BASE_URL;
+    }
     if (process.env.TABMINAL_DEBUG) finalConfig.debug = true;
     if (process.env.TABMINAL_GOOGLE_KEY) finalConfig.googleKey = process.env.TABMINAL_GOOGLE_KEY;
     if (process.env.TABMINAL_GOOGLE_CX) finalConfig.googleCx = process.env.TABMINAL_GOOGLE_CX;
+
+    // Validate model - ensure it's not empty string
+    if (finalConfig.model && typeof finalConfig.model === 'string' && finalConfig.model.trim() === '') {
+        // Reset to default if empty string
+        finalConfig.model = DEFAULT_CONFIG.model;
+    }
 
     // Password Logic
     if (!finalConfig.password) {

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -38,11 +38,35 @@ if (config.openrouterKey) {
             console.log('[Server] Web Search initialized (Google)');
         }
 
-        await alan.init({
+        // Ensure model is set for OpenRouter
+        if (!config.model || config.model.trim() === '') {
+            throw new Error('Model name or description is required for provider: OpenRouter. Please set --model or TABMINAL_MODEL environment variable.');
+        }
+
+        // Always use modelConfig to bypass utilitas predefined model list
+        // This ensures any OpenRouter model can be used without library constraints
+        const initOptions = {
             apiKey: config.openrouterKey,
-            model: config.model
-        });
-        console.log(`[Server] Alan initialized with model: ${config.model}`);
+            provider: 'OpenRouter',
+            modelConfig: {
+                name: config.model,
+                icon: '🤖',
+                defaultProvider: 'OpenRouter',
+                // Sensible defaults for most models
+                contextWindow: 128000,
+                maxOutputTokens: 16384,
+                json: true,
+                tools: true
+            }
+        };
+
+        // Support custom API base URL (for self-hosted or proxy services)
+        if (config.apiBaseUrl) {
+            initOptions.baseURL = config.apiBaseUrl;
+        }
+
+        await alan.init(initOptions);
+        console.log(`[Server] Alan initialized with model: ${config.model}${config.apiBaseUrl ? ` (API: ${config.apiBaseUrl})` : ''}`);
     } catch (e) {
         console.error('[Server] Failed to initialize Alan:', e.message);
     }


### PR DESCRIPTION
Problem:
When using --model or TABMINAL_MODEL with custom model names (e.g., "xiaomi/mimo-v2-flash:free"), alan.init() failed with error: "Model name or description is required for provider: OpenRouter."

Root cause:
The utilitas library's alan.init() searches for the model parameter in its predefined MODELS list. Custom models not in this list cause the assertion to fail.

Solution:
- Use modelConfig parameter instead of model parameter to bypass the predefined model list lookup
- Explicitly set provider: 'OpenRouter' to avoid default behavior
- Add sensible defaults (contextWindow, maxOutputTokens, json, tools) for compatibility with most models
- Add validation in config.mjs to handle empty string model values

New feature:
- Add --api-base-url (-u) option to support custom API endpoints
- Support TABMINAL_API_BASE_URL environment variable
- Support "api-base-url" in config.json
- This allows users to use self-hosted models, proxies, or other OpenAI-compatible APIs (e.g., DeepSeek, Ollama, local proxies)

Updated files:
- src/server.mjs: Use modelConfig, add baseURL support
- src/config.mjs: Add api-base-url parameter parsing
- config.sample.json: Add api-base-url example
- README.md: Update configuration table

> Generated by AI with vibes